### PR TITLE
installation: fix invenio_upgrader dependency

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -27,3 +27,5 @@
 #
 #     -e git+git://github.com/mitsuhiko/werkzeug.git#egg=Werkzeug
 #     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
+
+-e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ test_requirements = [
     'pytest_cov>=1.8.0,<2.0.0',
     'pytest_pep8>=1.0.6',
     'coverage>=3.7.1',
+    'invenio-upgrader>=0.1.0',
 ]
 
 


### PR DESCRIPTION
* FIX Adds missing `invenio_upgrader` dependency following its
  separation into standalone package.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>