### PR TITLE
installation: fix invenio_base imports

### DIFF
--- a/invenio_formatter/engine.py
+++ b/invenio_formatter/engine.py
@@ -23,8 +23,8 @@ import re
 import time
 import types
 
-from invenio.base.globals import cfg
-from invenio.base.i18n import language_list_long
+from invenio_base.globals import cfg
+from invenio_base.i18n import language_list_long
 from invenio.ext.template import render_template_to_string
 
 from werkzeug.utils import cached_property
@@ -197,7 +197,7 @@ def format_record(record, of, ln=None, verbose=0, search_pattern=None,
 def format_records(records, of='hb', ln=None, **ctx):
     """Return records using Jinja template."""
     from flask import request
-    from invenio.base.i18n import wash_language
+    from invenio_base.i18n import wash_language
     from .registry import export_formats
 
     of = of.lower()

--- a/invenio_formatter/manage.py
+++ b/invenio_formatter/manage.py
@@ -53,7 +53,7 @@ def expunge(output_format="HB"):
 
 def main():
     """Run manager."""
-    from invenio.base.factory import create_app
+    from invenio_base.factory import create_app
     app = create_app()
     manager.app = app
     manager.run()

--- a/invenio_formatter/template_context_functions/tfn_get_back_to_search_links.py
+++ b/invenio_formatter/template_context_functions/tfn_get_back_to_search_links.py
@@ -18,7 +18,7 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 from flask import session
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 from invenio.ext.template import render_template_to_string
 
 """

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -21,11 +21,6 @@
 # In applying this license, CERN does not
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
-#
-# TODO: Add development versions of some important dependencies here to get a
-#       warning when there are breaking upstream changes, e.g.:
-#
-#     -e git+git://github.com/mitsuhiko/werkzeug.git#egg=Werkzeug
-#     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
 
+-e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
 -e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,8 @@ history = open('CHANGES.rst').read()
 requirements = [
     'Flask>=0.10.1',
     'six>=1.7.2',
+    'invenio-base>=0.2.1',
+    'invenio-upgrader>=0.1.0',
 ]
 
 test_requirements = [
@@ -45,11 +47,11 @@ test_requirements = [
     'pytest_cov>=1.8.0,<2.0.0',
     'pytest_pep8>=1.0.6',
     'coverage>=3.7.1',
-    'invenio-upgrader>=0.1.0',
 ]
 
 
 class PyTest(TestCommand):
+
     """PyTest Test."""
 
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]


### PR DESCRIPTION
* FIX Adds missing `invenio_base` dependency and amends past
  upgrade recipes following its separation into standalone package.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>