### PR TITLE
installation: fix invenio_ext imports

### DIFF
--- a/invenio_formatter/bundles.py
+++ b/invenio_formatter/bundles.py
@@ -21,7 +21,7 @@
 
 from __future__ import unicode_literals
 
-from invenio.ext.assets import Bundle
+from invenio_ext.assets import Bundle
 
 
 css = Bundle(

--- a/invenio_formatter/engine.py
+++ b/invenio_formatter/engine.py
@@ -25,7 +25,7 @@ import types
 
 from invenio_base.globals import cfg
 from invenio_base.i18n import language_list_long
-from invenio.ext.template import render_template_to_string
+from invenio_ext.template import render_template_to_string
 
 from werkzeug.utils import cached_property
 

--- a/invenio_formatter/manage.py
+++ b/invenio_formatter/manage.py
@@ -27,7 +27,7 @@ import shutil
 
 from six import iteritems
 
-from invenio.ext.script import Manager
+from invenio_ext.script import Manager
 
 manager = Manager(usage=__doc__)
 
@@ -36,7 +36,7 @@ manager = Manager(usage=__doc__)
                 default="HB", help="Specify output format/s (default HB)")
 def expunge(output_format="HB"):
     """Remove static output formats from cache."""
-    from invenio.ext.sqlalchemy import db
+    from invenio_ext.sqlalchemy import db
     from .models import Bibfmt
 
     # Make it uppercased as it is stored in database.

--- a/invenio_formatter/models.py
+++ b/invenio_formatter/models.py
@@ -19,7 +19,7 @@
 
 """Database cache for formatter."""
 
-from invenio.ext.sqlalchemy import db
+from invenio_ext.sqlalchemy import db
 
 
 class Bibfmt(db.Model):

--- a/invenio_formatter/registry.py
+++ b/invenio_formatter/registry.py
@@ -27,7 +27,7 @@ from flask_registry import (
     RegistryProxy,
 )
 
-from invenio.ext.registry import ModuleAutoDiscoverySubRegistry
+from invenio_ext.registry import ModuleAutoDiscoverySubRegistry
 from invenio.utils.datastructures import LazyDict
 
 import yaml

--- a/invenio_formatter/template_context_functions/tfn_get_back_to_search_links.py
+++ b/invenio_formatter/template_context_functions/tfn_get_back_to_search_links.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2013 CERN.
+# Copyright (C) 2013, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 
 from flask import session
 from invenio_base.globals import cfg
-from invenio.ext.template import render_template_to_string
+from invenio_ext.template import render_template_to_string
 
 """
 Template context function - Display links (previous, next, back-to-search)

--- a/invenio_formatter/upgrades/formatter_2014_10_29_add_mime_type.py
+++ b/invenio_formatter/upgrades/formatter_2014_10_29_add_mime_type.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -18,7 +18,7 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 import warnings
-from invenio.ext.sqlalchemy import db
+from invenio_ext.sqlalchemy import db
 from invenio_upgrader.api import op
 from invenio.legacy.dbquery import run_sql
 

--- a/invenio_formatter/upgrades/formatter_2015_01_29_removal_of_format_tables.py
+++ b/invenio_formatter/upgrades/formatter_2015_01_29_removal_of_format_tables.py
@@ -21,7 +21,7 @@
 
 import warnings
 
-from invenio.ext.sqlalchemy import db
+from invenio_ext.sqlalchemy import db
 from invenio.legacy.dbquery import run_sql
 from invenio_upgrader.api import op
 

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -23,4 +23,5 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 -e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
+-e git+git://github.com/inveniosoftware/invenio-ext.git#egg=invenio-ext
 -e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ requirements = [
     'Flask>=0.10.1',
     'six>=1.7.2',
     'invenio-base>=0.2.1',
+    'invenio-ext>=0.1.0',
     'invenio-upgrader>=0.1.0',
 ]
 


### PR DESCRIPTION
* FIX Adds missing invenio_ext dependency and fixes its imports.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>