### PR TITLE
 bugfix: add invenio_formatter to testpaths in tool:pytest configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -83,5 +83,5 @@ ignore =
 
 [tool:pytest]
 addopts = --black --isort --pydocstyle --doctest-glob="*.rst" --doctest-modules --cov=invenio_formatter --cov-report=term-missing
-testpaths = tests
+testpaths = tests invenio_formatter
 filterwarnings = ignore::pytest.PytestDeprecationWarning


### PR DESCRIPTION
otherwise e.g. black is not tested in this directory
