### PR TITLE
setup: fix pillow `ImageDraw.textsize()` deprecated method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
 Changes
 =======
 
+Version 1.3.1 (released 2023-07-19)
+
+- setup: fix for `pillow.ImageDraw.textsize` deprecated method
+
 Version 1.3.0 (released 2023-07-17)
 
 - add template filter for human readable time

--- a/invenio_formatter/__init__.py
+++ b/invenio_formatter/__init__.py
@@ -70,6 +70,6 @@ from __future__ import absolute_import, print_function
 
 from .ext import InvenioFormatter
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 
 __all__ = ("__version__", "InvenioFormatter")

--- a/invenio_formatter/context_processors/badges.py
+++ b/invenio_formatter/context_processors/badges.py
@@ -16,6 +16,18 @@ import cairosvg
 from PIL import Image, ImageDraw, ImageFont
 
 
+def _get_image_draw_size(image_draw, value, font):
+    """Helper to keep backwards compatibility with pillow<10.0."""
+    textsize = 0
+    try:
+        textsize = image_draw.textsize(value, font=font)[0]
+    except AttributeError:
+        # ImageDraw.textsize was replaced by ImageDraw.textlength in v10.0.0
+        # See https://github.com/python-pillow/Pillow/blob/main/docs/deprecations.rst#font-size-and-offset-methods
+        textsize = image_draw.textlength(value, font=font)[0]
+    return textsize
+
+
 def get_text_length(*args):
     r"""Measure the size of string rendered with a TTF no-nomospaced fonts.
 
@@ -24,10 +36,11 @@ def get_text_length(*args):
     """
     txt = Image.new("RGBA", (16, 16), (255, 255, 255, 0))
     d = ImageDraw.Draw(txt)
+
     font = ImageFont.truetype("DejaVuSans", 11)
     result = ()
     for value in args:
-        result = result + (d.textsize(value, font=font)[0],)
+        result = result + (_get_image_draw_size(d, value, font=font),)
     return result
 
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Please describe briefly your pull request.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
