### PR TITLE
fix: pkg_resources DeprecationWarning

### DIFF
--- a/invenio_formatter/ext.py
+++ b/invenio_formatter/ext.py
@@ -2,13 +2,14 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Jinja utilities for Invenio."""
 
-from pkg_resources import DistributionNotFound, get_distribution
+from importlib.metadata import PackageNotFoundError, distribution
 
 from . import config
 from .filters.datetime import (
@@ -72,9 +73,9 @@ class InvenioFormatter(object):
         :param app: The Flask application.
         """
         try:
-            get_distribution("CairoSVG")
+            distribution("CairoSVG")
             has_cairo = True
-        except DistributionNotFound:
+        except PackageNotFoundError:
             has_cairo = False
 
         app.config.setdefault("FORMATTER_BADGES_ENABLE", has_cairo)

--- a/tests/test_invenio_formatter.py
+++ b/tests/test_invenio_formatter.py
@@ -2,15 +2,17 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Module tests."""
 
+from importlib.metadata import PackageNotFoundError
+
 from flask import Flask
 from mock import patch
-from pkg_resources import DistributionNotFound
 
 from invenio_formatter import InvenioFormatter
 
@@ -42,8 +44,8 @@ def test_badge_enable_disable():
     assert app.config["FORMATTER_BADGES_ENABLE"] is True
     assert "invenio_formatter_badges" in app.blueprints
 
-    with patch("invenio_formatter.ext.get_distribution") as f:
-        f.side_effect = DistributionNotFound
+    with patch("invenio_formatter.ext.distribution") as distribution:
+        distribution.side_effect = PackageNotFoundError
 
         app = Flask("testapp")
         InvenioFormatter(app)


### PR DESCRIPTION
* UserWarning: pkg_resources is deprecated as an API. See
  https://setuptools.pypa.io/en/latest/pkg_resources.html. The
  pkg_resources package is slated for removal as early as 2025-11-30.
  Refrain from using this package or pin to Setuptools<81.
