### PR TITLE
Enable optional caching of badges

### DIFF
--- a/invenio_formatter/config.py
+++ b/invenio_formatter/config.py
@@ -11,3 +11,6 @@ FORMATTER_BADGES_TITLE_MAPPING = {}
 
 FORMATTER_BADGES_MAX_CACHE_AGE = 0
 """The maximum amount of time a badge will be considered fresh."""
+
+FORMATTER_BADGES_DENY_CACHING = True
+"""Set response header fields to prevent caching of generated badges."""

--- a/invenio_formatter/views.py
+++ b/invenio_formatter/views.py
@@ -64,15 +64,20 @@ def create_badge_blueprint(allowed_types):
         # Generate Etag from badge title and value.
         hashable_badge = "{0}.{1}".format(badge_title_mapping, value).encode("utf-8")
         response.set_etag(hashlib.sha1(hashable_badge).hexdigest())
-        # Add headers to prevent caching.
-        response.headers["Pragma"] = "no-cache"
-        response.cache_control.no_cache = True
-        response.cache_control.max_age = current_app.config[
-            "FORMATTER_BADGES_MAX_CACHE_AGE"
-        ]
-        response.last_modified = dt.now(timezone.utc)
-        extra = timedelta(seconds=current_app.config["FORMATTER_BADGES_MAX_CACHE_AGE"])
-        response.expires = response.last_modified + extra
+
+        if current_app.config.get("FORMATTER_BADGES_DENY_CACHING", True):
+            # Add headers to prevent caching, if configured.
+            response.headers["Pragma"] = "no-cache"
+            response.cache_control.no_cache = True
+            response.cache_control.max_age = current_app.config[
+                "FORMATTER_BADGES_MAX_CACHE_AGE"
+            ]
+            response.last_modified = dt.now(timezone.utc)
+            extra = timedelta(
+                seconds=current_app.config["FORMATTER_BADGES_MAX_CACHE_AGE"]
+            )
+            response.expires = response.last_modified + extra
+
         return response.make_conditional(request)
 
     return blueprint

--- a/invenio_formatter/views.py
+++ b/invenio_formatter/views.py
@@ -78,6 +78,12 @@ def create_badge_blueprint(allowed_types):
             )
             response.expires = response.last_modified + extra
 
+        else:
+            response.cache_control.public = True
+            response.cache_control.max_age = current_app.config[
+                "FORMATTER_BADGES_MAX_CACHE_AGE"
+            ]
+
         return response.make_conditional(request)
 
     return blueprint


### PR DESCRIPTION
This PR makes it optionally possible to *not* set HTTP headers that will prevent caching of badges, with settings like the following:
* `FORMATTER_BADGES_DENY_CACHING = False`
* `FORMATTER_BADGES_MAX_CACHE_AGE = 86400`

This at least enables clients (like browsers) to cache the badges (which in their current form are basically just static assets anyway, but dynamically generated via code).